### PR TITLE
Fix conflict with Google Calendar styles

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -39,7 +39,6 @@
     "@maxxxxxdlp/stylelint-config": "^1.0.0",
     "@rushstack/eslint-patch": "^1.1.4",
     "@stylelint/postcss-css-in-js": "^0.38.0",
-    "@tailwindcss/forms": "^0.5.2",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^14.4.3",

--- a/src/tailwind.config.js
+++ b/src/tailwind.config.js
@@ -73,5 +73,4 @@ module.exports = {
       },
     },
   },
-  plugins: [require('@tailwindcss/forms')],
 };


### PR DESCRIPTION
Disable the Tailwind Forms plugin as it was overwriting Google Calendar styles, while not being used by the extension.

If we would need that plugin again in the future, we could add it back

Fixes #31