### PR TITLE
Add OAuth integration to allow for Google Calendar API calls

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,11 +11,21 @@
     "48": "./src/public/images/extension_icon_48x48.png",
     "128": "./src/public/images/extension_icon_128x128.png"
   },
+  "action": {
+    "default_title": "See where your time went"
+  },
+  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuldA6s8qQKAdu33VanYX4yhBYnTbMwARskX7rcwvuIKgRPbY41X1mcIDUHKV7pC5sWQ2QuL0EN5U6M57dJhe+veTDDktpWNXeGJtwvPM6HFbwICgD93TkzwBl4Fs+67eFlsmpoHIdWeryyEfIUAgUwsb8DxvQ8OYhVKet1xkqJRRo112iLZ1bn/ZI8P39jT4cc9pMIXSvEKmtzyqNb9l/5WS8F6reqsRGIwZqmr/9fb7CEhyKPzEtXokcfaTygMwF6rJ6530cLUegofpJed4wZfFCCRtok63aqCwQgfypOKWlXCrExTdD6QKP4941dYQMuCg9+wp/GslGwTUd+odGQIDAQAB",
   "current_locale": "en",
   "permissions": [
     "identity",
     "storage"
   ],
+  "oauth2": {
+    "client_id": "626996674772-iegg1iono3q4g3u8e3ajcp37fbuauuh1.apps.googleusercontent.com",
+    "scopes":[
+      "https://www.googleapis.com/auth/calendar.readonly"
+    ]
+  },
   "background": {
     "service_worker":"./src/dist/background.bundle.js"
   },

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -29,6 +29,7 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^14.4.3",
         "@types/chrome": "^0.0.197",
+        "@types/gapi.calendar": "^3.0.6",
         "@types/jest": "^29.0.3",
         "@types/node": "^18.7.18",
         "@types/react": "^18.0.20",
@@ -3761,6 +3762,21 @@
       "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.29.tgz",
       "integrity": "sha512-BsPXH/irW0ht0Ji6iw/jJaK8Lj3FJemon2gvEqHKpCdDCeemHa+rI3WBGq5z7cDMZgoLjY40oninGxqk+8NzNQ==",
       "dev": true
+    },
+    "node_modules/@types/gapi": {
+      "version": "0.0.42",
+      "resolved": "https://registry.npmjs.org/@types/gapi/-/gapi-0.0.42.tgz",
+      "integrity": "sha512-kskWpouTGqutaIVRo/swiGnMVoRxOYdRwvaDrh0yavfR9vQoHvJJ7Enp4KE9MEGS8qF7F5KiP6bRNOYcCgRXCA==",
+      "dev": true
+    },
+    "node_modules/@types/gapi.calendar": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/gapi.calendar/-/gapi.calendar-3.0.6.tgz",
+      "integrity": "sha512-5POp+QFcJh7yHHOaOc3pkvEZq99u8EzaHuAL+0XcrNKQpN6EM9T6guQ2Q2O39KWkxGvAKdshDv2ZwB7I+v+t3A==",
+      "dev": true,
+      "dependencies": {
+        "@types/gapi": "*"
+      }
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
@@ -19138,6 +19154,21 @@
       "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.29.tgz",
       "integrity": "sha512-BsPXH/irW0ht0Ji6iw/jJaK8Lj3FJemon2gvEqHKpCdDCeemHa+rI3WBGq5z7cDMZgoLjY40oninGxqk+8NzNQ==",
       "dev": true
+    },
+    "@types/gapi": {
+      "version": "0.0.42",
+      "resolved": "https://registry.npmjs.org/@types/gapi/-/gapi-0.0.42.tgz",
+      "integrity": "sha512-kskWpouTGqutaIVRo/swiGnMVoRxOYdRwvaDrh0yavfR9vQoHvJJ7Enp4KE9MEGS8qF7F5KiP6bRNOYcCgRXCA==",
+      "dev": true
+    },
+    "@types/gapi.calendar": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/gapi.calendar/-/gapi.calendar-3.0.6.tgz",
+      "integrity": "sha512-5POp+QFcJh7yHHOaOc3pkvEZq99u8EzaHuAL+0XcrNKQpN6EM9T6guQ2Q2O39KWkxGvAKdshDv2ZwB7I+v+t3A==",
+      "dev": true,
+      "requires": {
+        "@types/gapi": "*"
+      }
     },
     "@types/graceful-fs": {
       "version": "4.1.5",

--- a/src/package.json
+++ b/src/package.json
@@ -43,6 +43,7 @@
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^14.4.3",
     "@types/chrome": "^0.0.197",
+    "@types/gapi.calendar": "^3.0.6",
     "@types/jest": "^29.0.3",
     "@types/node": "^18.7.18",
     "@types/react": "^18.0.20",

--- a/src/src/components/App/__tests__/index.test.tsx
+++ b/src/src/components/App/__tests__/index.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { App } from './index';
-import { mount } from '../../tests/reactUtils';
-import { commonText } from '../../localization/common';
-import { CurrentViewContext } from '../Core/CurrentViewContext';
-import { testTime } from '../../tests/helpers';
+import { App } from '../index';
+import { mount } from '../../../tests/reactUtils';
+import { commonText } from '../../../localization/common';
+import { CurrentViewContext } from '../../Core/CurrentViewContext';
+import { testTime } from '../../../tests/helpers';
 
 test('does not render until current date is extracted', () => {
   const { container } = mount(

--- a/src/src/components/App/index.tsx
+++ b/src/src/components/App/index.tsx
@@ -4,44 +4,56 @@ import { useBooleanState } from '../../hooks/useBooleanState';
 import { Portal } from '../Molecules/Portal';
 import { Dashboard } from '../Dashboard';
 import { CurrentViewContext } from '../Core/CurrentViewContext';
+import { AuthContext } from '../Core/AuthContext';
 
-// Allowing for the class to be overriden from here
-const testWidgets : Array<WidgetObj> = [
-  { header: "Header 1", body: "Body 1" },
-  { header: "Header 2", body: "Body 2" },
-  { header: "Header 3", body: "Body 3" },
-  { header: "Header 4", body: "Body 4" },
-  { header: "Header 5", body: "Body 5" },
-  { header: "Header 6", body: "Body 6" },
-  { header: "Header 7", body: "Body 7" },
-  { header: "Header 8", body: "Body 8" }
-]
+// Allowing for the class to be overridden from here
+const testWidgets: Array<WidgetObj> = [
+  { header: 'Header 1', body: 'Body 1' },
+  { header: 'Header 2', body: 'Body 2' },
+  { header: 'Header 3', body: 'Body 3' },
+  { header: 'Header 4', body: 'Body 4' },
+  { header: 'Header 5', body: 'Body 5' },
+  { header: 'Header 6', body: 'Body 6' },
+  { header: 'Header 7', body: 'Body 7' },
+  { header: 'Header 8', body: 'Body 8' },
+];
 
 export function App(): JSX.Element | null {
   const [isOpen, _, handleClose, handleToggle] = useBooleanState();
 
   React.useEffect(() => {
     const handleEscKey = (event: KeyboardEvent): void =>
-      event.key === "Escape"
-        ? handleClose()
-        : undefined;
+      event.key === 'Escape' ? handleClose() : undefined;
 
-    document.addEventListener("keydown", handleEscKey, false);
-    return () => document.removeEventListener("keydown", handleEscKey, false);
+    document.addEventListener('keydown', handleEscKey, false);
+    return () => document.removeEventListener('keydown', handleEscKey, false);
   }, []);
 
   const currentView = React.useContext(CurrentViewContext);
+  const auth = React.useContext(AuthContext);
 
   return typeof currentView === 'object' ? (
     <>
-      <button type="button" onClick={handleToggle} aria-pressed={isOpen}>
+      <button
+        type="button"
+        onClick={
+          auth.authenticated
+            ? handleToggle
+            : (): void =>
+                void auth
+                  .handleAuthenticate()
+                  .then(handleToggle)
+                  .catch(console.error)
+        }
+        aria-pressed={isOpen}
+      >
         {commonText('calendarPlus')}
       </button>
       {isOpen && (
         <Portal>
           <main className="h-full">
+            <pre>{JSON.stringify({ currentView, auth }, null, 4)}</pre>
             <Dashboard closeHandler={handleClose} widgets={testWidgets} />
-            <pre>Debug: {JSON.stringify(currentView)}</pre>
           </main>
         </Portal>
       )}

--- a/src/src/components/App/index.tsx
+++ b/src/src/components/App/index.tsx
@@ -5,6 +5,7 @@ import { Portal } from '../Molecules/Portal';
 import { Dashboard } from '../Dashboard';
 import { CurrentViewContext } from '../Core/CurrentViewContext';
 import { AuthContext } from '../Core/AuthContext';
+import { ListCalendars } from '../Dashboard/ListCalendars';
 
 // Allowing for the class to be overridden from here
 const testWidgets: Array<WidgetObj> = [
@@ -51,9 +52,11 @@ export function App(): JSX.Element | null {
       </button>
       {isOpen && (
         <Portal>
-          <main className="h-full">
-            <pre>{JSON.stringify({ currentView, auth }, null, 4)}</pre>
+          <main className="h-full overflow-y-auto">
             <Dashboard closeHandler={handleClose} widgets={testWidgets} />
+            <pre>{JSON.stringify({ currentView, auth }, null, 4)}</pre>
+            {/* This is used just an example of how to make an API call: */}
+            <ListCalendars />
           </main>
         </Portal>
       )}

--- a/src/src/components/Background/index.ts
+++ b/src/src/components/Background/index.ts
@@ -1,9 +1,45 @@
+import { emitEvent, Requests } from './messages';
+import { State } from 'typesafe-reducer';
+
 // Based on https://stackoverflow.com/a/50548409/8584605
 chrome.tabs.onUpdated.addListener(function (tabId, changeInfo) {
   if (changeInfo?.status === 'complete')
-    chrome.tabs
-      .sendMessage(tabId, { message: 'tabUpdate' })
-      .catch(console.trace);
+    emitEvent(tabId, { type: 'TabUpdate' }).catch(console.trace);
 });
+
+/**
+ * Listen for a message from the front-end and send back the response
+ */
+chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
+  if (
+    typeof request === 'object' &&
+    request !== null &&
+    request.type in requestHandlers
+  ) {
+    requestHandlers[request.type as Requests['type']](request.request)
+      .then(sendResponse)
+      .catch(console.error);
+    return true;
+  }
+  return undefined;
+});
+
+/**
+ * Handlers for the front-end requests
+ */
+const requestHandlers: {
+  readonly [TYPE in Requests['type']]: (
+    request: (State<TYPE> & Requests)['request']
+  ) => Promise<(State<TYPE> & Requests)['response']>;
+} = {
+  Authenticate: ({ interactive }) =>
+    new Promise((resolve, reject) =>
+      chrome.identity.getAuthToken({ interactive }, (token) =>
+        typeof token === 'string'
+          ? resolve({ token })
+          : reject(chrome.runtime.lastError)
+      )
+    ),
+};
 
 export {};

--- a/src/src/components/Background/messages.ts
+++ b/src/src/components/Background/messages.ts
@@ -1,0 +1,64 @@
+/**
+ * Message passing utils. Used both by the context and background scripts
+ */
+
+import { State } from 'typesafe-reducer';
+
+type AuthenticateRequest = State<
+  'Authenticate',
+  {
+    readonly request: {
+      readonly interactive: boolean;
+    };
+    readonly response: {
+      readonly token: string | undefined;
+    };
+  }
+>;
+
+export type Requests = AuthenticateRequest;
+
+/**
+ * Send a request to the background script and await the response.
+ * Should be called from the content script
+ */
+export const sendRequest = async <TYPE extends Requests['type']>(
+  type: TYPE,
+  request: (Requests & State<TYPE>)['request']
+): Promise<(Requests & State<TYPE>)['response']> =>
+  chrome.runtime.sendMessage({
+    type,
+    request,
+  });
+
+type TabUpdate = State<'TabUpdate'>;
+type BackgroundEvents = TabUpdate;
+
+/**
+ * Emit an event. Must be called from a background script only
+ */
+export function emitEvent(
+  tabId: number,
+  response: BackgroundEvents
+): Promise<void> {
+  if (chrome.tabs === undefined)
+    throw new Error('This must only be called from the background script');
+  return chrome.tabs.sendMessage(tabId, response);
+}
+
+/**
+ * Listen for an event emitted by the background script.
+ * Call this from the content script.
+ */
+export function listenEvent<TYPE extends BackgroundEvents['type']>(
+  type: TYPE,
+  callback: (payload: BackgroundEvents & State<TYPE>) => void
+): () => void {
+  const handleUpdate = (event: BackgroundEvents & State<TYPE>) =>
+    typeof event === 'object' && event !== null && event.type === type
+      ? callback(event)
+      : undefined;
+
+  chrome.runtime.onMessage.addListener(handleUpdate);
+  return (): void => chrome.runtime.onMessage.removeListener(handleUpdate);
+}

--- a/src/src/components/Core/AuthContext.tsx
+++ b/src/src/components/Core/AuthContext.tsx
@@ -13,6 +13,9 @@ type NotAuthenticated = {
 
 type Auth = Authenticated | NotAuthenticated;
 
+let unsafeToken: string | undefined = undefined;
+export const unsafeGetToken = () => unsafeToken;
+
 export function AuthenticationProvider({
   children,
 }: {
@@ -21,14 +24,15 @@ export function AuthenticationProvider({
   const handleAuthenticate = React.useCallback(
     (interactive = true) =>
       sendRequest('Authenticate', { interactive })
-        .then(({ token }) =>
-          typeof token === 'string'
-            ? setAuth({
-                authenticated: true,
-                token,
-              })
-            : console.warn('Authentication canceled')
-        )
+        .then(({ token }) => {
+          if (typeof token === 'string') {
+            unsafeToken = token;
+            setAuth({
+              authenticated: true,
+              token,
+            });
+          } else console.warn('Authentication canceled');
+        })
         .catch(console.error),
     []
   );

--- a/src/src/components/Core/AuthContext.tsx
+++ b/src/src/components/Core/AuthContext.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { sendRequest } from '../Background/messages';
+
+type Authenticated = {
+  readonly authenticated: true;
+  readonly token: string;
+};
+
+type NotAuthenticated = {
+  readonly authenticated: false;
+  readonly handleAuthenticate: () => Promise<void>;
+};
+
+type Auth = Authenticated | NotAuthenticated;
+
+export function AuthenticationProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}): JSX.Element {
+  const handleAuthenticate = React.useCallback(
+    (interactive = true) =>
+      sendRequest('Authenticate', { interactive })
+        .then(({ token }) =>
+          typeof token === 'string'
+            ? setAuth({
+                authenticated: true,
+                token,
+              })
+            : console.warn('Authentication canceled')
+        )
+        .catch(console.error),
+    []
+  );
+  React.useEffect(() => void handleAuthenticate(false), [handleAuthenticate]);
+
+  const [auth, setAuth] = React.useState<Auth>({
+    authenticated: false,
+    handleAuthenticate,
+  });
+  return <AuthContext.Provider value={auth}>{children}</AuthContext.Provider>;
+}
+
+export const AuthContext = React.createContext<Auth>({
+  authenticated: false,
+  handleAuthenticate: () => {
+    throw new Error('AuthContext is not defined');
+  },
+});
+AuthContext.displayName = 'AuthContext';

--- a/src/src/components/Core/Contexts.tsx
+++ b/src/src/components/Core/Contexts.tsx
@@ -6,6 +6,7 @@ import type { RA } from '../../utils/types';
 import { ErrorBoundary } from '../Errors/ErrorBoundary';
 import { useBooleanState } from '../../hooks/useBooleanState';
 import { TrackCurrentView } from './CurrentViewContext';
+import { AuthenticationProvider } from './AuthContext';
 
 /**
  * Provide contexts used by other components
@@ -47,11 +48,13 @@ export function Contexts({
     <ErrorBoundary>
       <LoadingContext.Provider key="loadingContext" value={loadingHandler}>
         <TrackCurrentView>
-          {/* FEATURE: replace this with a toast, dialog, or status line*/}
-          {isLoading && commonText('loading')}
-          <React.Suspense fallback={<>{commonText('loading')}</>}>
-            {children}
-          </React.Suspense>
+          <AuthenticationProvider>
+            {/* FEATURE: replace this with a toast, dialog, or status line*/}
+            {isLoading && commonText('loading')}
+            <React.Suspense fallback={<>{commonText('loading')}</>}>
+              {children}
+            </React.Suspense>
+          </AuthenticationProvider>
         </TrackCurrentView>
       </LoadingContext.Provider>
     </ErrorBoundary>

--- a/src/src/components/Core/CurrentViewContext.tsx
+++ b/src/src/components/Core/CurrentViewContext.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { listenEvent } from '../Background/messages';
 
 /*
  * "customday" is a user-customizable view (they can change the number of days
@@ -43,16 +44,11 @@ function useCurrentTracker(
     // Parse initial URL
     parseUrl();
 
-    function handleUpdate(request: { readonly message: string }) {
-      if (request.message !== 'tabUpdate') return;
+    return listenEvent('TabUpdate', () => {
       if (window.location.pathname === lastPath) return;
       lastPath = window.location.pathname;
       parseUrl();
-    }
-
-    // Listen for message from ../Background/index.ts
-    chrome.runtime.onMessage.addListener(handleUpdate);
-    return (): void => chrome.runtime.onMessage.removeListener(handleUpdate);
+    });
   }, [setCurrentView]);
 }
 

--- a/src/src/components/Dashboard/ListCalendars.tsx
+++ b/src/src/components/Dashboard/ListCalendars.tsx
@@ -1,0 +1,23 @@
+import { useAsyncState } from '../../hooks/useAsyncState';
+import { ajax } from '../../utils/ajax';
+import { commonText } from '../../localization/common';
+import React from 'react';
+import { RA } from '../../utils/types';
+
+type CalendarListEntry = gapi.client.calendar.CalendarListEntry;
+
+export function ListCalendars(): JSX.Element {
+  const [calendars] = useAsyncState<RA<CalendarListEntry>>(
+    React.useCallback(
+      () =>
+        ajax('https://www.googleapis.com/calendar/v3/users/me/calendarList')
+          .then((response) => response.json())
+          .then((results) => results.items),
+      []
+    ),
+    false
+  );
+  return (
+    <pre>{JSON.stringify(calendars ?? commonText('loading'), null, 4)}</pre>
+  );
+}

--- a/src/src/components/Dashboard/index.tsx
+++ b/src/src/components/Dashboard/index.tsx
@@ -15,7 +15,7 @@ export const Dashboard = (props: {
           {commonText('close')}
         </button>
       </div>
-      <div className="flex h-full w-full flex-row flex-wrap overflow-y-scroll scroll-auto text-center opacity-90">
+      <div className="flex flex-row flex-wrap scroll-auto text-center opacity-90">
         {props.widgets.map((widgObj) => (
           <Widget key={widgObj.header} widgObj={widgObj} />
         ))}

--- a/src/src/utils/__tests__/functools.test.ts
+++ b/src/src/utils/__tests__/functools.test.ts
@@ -1,4 +1,4 @@
-import {f} from '../functools';
+import { f } from '../functools';
 
 describe('f.includes', () => {
   test('positive case', () => expect(f.includes([1, 2, 3], 1)).toBe(true));

--- a/src/src/utils/ajax.ts
+++ b/src/src/utils/ajax.ts
@@ -1,0 +1,55 @@
+import { IR, RA } from './types';
+import { unsafeGetToken } from '../components/Core/AuthContext';
+
+/**
+ * All front-end network requests should go through this utility.
+ *
+ * Wraps native fetch in useful helpers
+ *
+ * @remarks
+ * Requests to Google APIs automatically attach the access token
+ * Automatically stringifies request body
+ */
+export const ajax = async (
+  url: string,
+  {
+    headers,
+    body,
+    ...options
+  }: Omit<RequestInit, 'body'> & {
+    // If object is passed to body, it is stringified
+    readonly body?: IR<unknown> | RA<unknown> | string | FormData;
+  } = {}
+): Promise<Response> =>
+  fetch(url, {
+    ...options,
+    headers: {
+      ...putToken(url),
+      ...headers,
+    },
+    body:
+      typeof body === 'object' && !(body instanceof FormData)
+        ? JSON.stringify(body)
+        : body,
+  });
+
+/**
+ * Include Google OAuth token if needed
+ */
+function putToken(url: string): { readonly Authorization: string } | undefined {
+  if (isGoogleApiUrl(url)) {
+    const token = unsafeGetToken();
+    if (token === undefined)
+      throw new Error(
+        `Tried to access Google API before authentication: ${url}`
+      );
+    else return { Authorization: `Bearer ${token}` };
+  } else return undefined;
+}
+
+/**
+ * Check if URL belongs to a Google API
+ */
+const isGoogleApiUrl = (url: string): boolean =>
+  new URL(url, globalThis.location.origin).origin ===
+  'https://www.googleapis.com';


### PR DESCRIPTION
Clicking on the `Calendar Stats` button now opens the Google sign-in screen if you are not signed in yet.

Afterward, the dashboard is opened, and the list of user's calendars is fetched using Google Calendar API (I added it just to serve as an example of how to do it).

I also added a helper method `ajax()`, which has identical interface to `fetch()`, but automatically adds authentication token when calling Google APIs.

FYI, here is the documentation I followed if you are interested in how OAuth integration works: https://developer.chrome.com/docs/extensions/mv3/tut_oauth/

You might notice that the API requests are sent using HTTP, rather than though an SDK. This is because Google API SDK is not supported in Chrome Extensions Manifest v3! I know, this is insane! More details:

The Google Calendar SDK must be loaded by the extension from an external url, it can not be bundled together
The Chrome Extension Manifest v3 forbid importing external JavaScript
Thus, the Google API SDKs no longer works in Chrome Extensions and they still haven't fixed it
Sources:
https://bugs.chromium.org/p/chromium/issues/detail?id=1164452
https://github.com/google/google-api-javascript-client/blob/master/docs/start.md#supported-environments 

Thus, we would have to manually send the HTTP requests to google calendar APIs, rather than have an SDK do that for us